### PR TITLE
Refactor coininfo versions structure

### DIFF
--- a/lib/coininfo.js
+++ b/lib/coininfo.js
@@ -3,7 +3,7 @@ module.exports = coininfo;
 /*** eventually support other info like ports for use in a generic https://github.com/cryptocoinjs/btc-p2p ***/
 
 var map = {
-  // [ Public version, Private version, P2SH version ]
+  // [ Public version, Private version, script hash version ]
   "BTC":       [0x00, 0x80, 0x05],
   "BTC-TEST":  [0x6F, 0xEF, 0xC4],
 
@@ -31,5 +31,5 @@ function coininfo(input) {
     console.warn('coininfo: '+input+' is deprecated, please check the current list of supported coins');
   }
 
-  return {versions: {public: versions[0], private: versions[1], p2sh: versions[2]}};
+  return {versions: {public: versions[0], private: versions[1], scripthash: versions[2]}};
 }


### PR DESCRIPTION
P2SH is part of the cryptocurrency, and not something standalone. IMHO it makes more sense to represent it that way. Also, some crypto-currencies have different version bytes for P2SH, which can't work with the previous format.

I changed the P2SH handling, as well as a few other small changes:
- Moved P2SH version into each cryptocurrency, rather than being represented as its own cryptocurrency
- Return P2SH version as a new `p2sh` key in the versions object
- Renamed TEST to BTC-TEST
- Added deprecation warning for TEST (now BTC-TEST), P2SH (now part of BTC) and TEST-P2SH (now part of BTC-TEST)
- Added LTC-TEST (wanted to add NMC-TEST too, but couldn't figure out the version bytes)
