### PR TITLE
remove backwards compatible code, use npm versioning instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Usage
 
 ```js
 var coininfo = require('coininfo');
-console.dir(coininfo('LTC')) // => { versions: { public: 48, private: 176, scripthash: 5} }
+console.dir(coininfo('LTC'))
+// => { versions: { public: 48, private: 176, scripthash: 5} }
 ```
 
 Useful to use in conjunction with [coinkey](https://github.com/cryptocoinjs/coinkey) and [coinstring](https://github.com/cryptocoinjs/coinstring).

--- a/lib/coininfo.js
+++ b/lib/coininfo.js
@@ -13,23 +13,18 @@ var map = {
   "LTC":       [0x30, 0xB0, 0x05],
   "LTC-TEST":  [0x6F, 0xEF, 0xC4],
 
-  "NMC":       [0x34, 0xB4, 0x05],
-  
-  // Left for backward compatibility
-  // Those are all version bytes for Bitcoin
-  "TEST": [0x6E, 0xEF],
-  "P2SH": [0x05, null],
-  "TEST-P2SH": [0xC4]
-
+  "NMC":       [0x34, 0xB4, 0x05]
 }
 
 function coininfo(input) {
   input = input.toUpperCase();
   var versions = map[input];
   if (!versions) return null;
-  if (versions.length < 3) {
-    console.warn('coininfo: '+input+' is deprecated, please check the current list of supported coins');
-  }
-
-  return {versions: {public: versions[0], private: versions[1], scripthash: versions[2]}};
+  return {
+    versions: {
+      public: versions[0],
+      private: versions[1],
+      scripthash: versions[2]
+    }
+  };
 }


### PR DESCRIPTION
Removed code for backwards compatibility. If you publish this as 0.2.0, code that needs to be backwards compatible can still use 0.1.0. Let npm and package.json take care of the rest :)

Note that I also changed the return value to an empty object instead of returning null if no info can be found for a particular coin.

I aim to add more support for default ports (could also have default rpc port) and also for network magic numbers.
