### PR TITLE
update Dash values to match 0.12.1 release

### DIFF
--- a/lib/coins/dash.js
+++ b/lib/coins/dash.js
@@ -20,10 +20,10 @@ var main = assign({}, {
   },
   // vSeeds
   seedsDns: [
-    'darkcoin.io',
-    'dnsseed.darkcoin.io',
-    'darkcoin.qa',
-    'dnsseed.darkcoin.qa',
+    'dash.org',
+    'dnsseed.dash.org',
+    'dashdot.io',
+    'dnsseed.dashdot.io',
     'masternode.io',
     'dnsseed.masternode.io',
     'dashpay.io',
@@ -32,8 +32,8 @@ var main = assign({}, {
   // base58Prefixes
   versions: {
     bip32: {
-      private: 0x02FE52CC,
-      public: 0x02FE52F8
+      private: 0x0488ade4,
+      public: 0x0488b21e
     },
     bip44: 5,
     private: 0xcc,
@@ -47,21 +47,19 @@ var test = assign({}, {
   port: 19999,
   portRpc: 19998,
   seedsDns: [
-    'darkcoin.io',
-    'testnet-seed.darkcoin.io',
-    'darkcoin.qa',
-    'testnet-seed.darkcoin.qa',
+    'dashdot.io',
+    'testnet-seed.dashdot.io',
     'masternode.io',
     'test.dnsseed.masternode.io'
   ],
   versions: {
     bip32: {
-      private: 0x3a805837,
-      public: 0x3a8061a0
+      private: 0x04358394,
+      public: 0x043587cf
     },
     bip44: 1,
     private: 0xef,
-    public: 0x8b,
+    public: 0x8c,
     scripthash: 0x13
   }
 }, common)


### PR DESCRIPTION
References:
- dns seeds https://github.com/dashpay/dash/pull/1395
- testnet pubkey version https://github.com/dashpay/dash/pull/767/files#diff-64cbe1ad5465e13bc59ee8bb6f3de2e7R222
- bip32 https://github.com/dashpay/dash/pull/926