### PR TITLE
Update standard linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "devDependencies": {
     "mocha": "^2.4.4",
-    "standard": "5.x"
+    "standard": "^9.x"
   },
   "repository": {
     "url": "https://github.com/cryptocoinjs/coininfo",


### PR DESCRIPTION
Not 10.x because that version forbid use `new Buffer`