### PR TITLE
node ~>8.0 implies npm installl --save

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Works in Node.js and the browser.
 Installation
 ------------
 
-    npm i --save coininfo
+    npm i coininfo
 
 
 Usage


### PR DESCRIPTION
"--save is no longer necessary as all installs will be saved by default..."
[Rising Stack](https://blog.risingstack.com/important-features-fixes-node-js-version-8/)