### PR TITLE
Updating QTUM because they added a new BIP44 constant...

### DIFF
--- a/lib/coins/qtum.js
+++ b/lib/coins/qtum.js
@@ -26,7 +26,7 @@ var main = Object.assign({}, {
       private: 0x0488ade4,
       public: 0x0488b21e
     },
-    bip44: 88,
+    bip44: 2301,
     private: 0x80,
     public: 0x3A,
     scripthash: 0x32


### PR DESCRIPTION
...instead of using BitBean.

Now `2301`:
https://github.com/satoshilabs/slips/blob/master/slip-0044.md