### PR TITLE
Add support for messagePrefix field

### DIFF
--- a/lib/coininfo.js
+++ b/lib/coininfo.js
@@ -66,7 +66,7 @@ coins.forEach(function (coin) {
 
 function toBitcoinJS () {
   return Object.assign({}, this, {
-    messagePrefix: null, // TODO
+    messagePrefix: this.versions.messagePrefix || ('\x19' + this.versions.name + ' Signed Message:\n'),
     bip32: {
       public: this.versions.bip32.public,
       private: this.versions.bip32.private

--- a/lib/coins/btc.js
+++ b/lib/coins/btc.js
@@ -6,7 +6,8 @@
 var common = {
   name: 'Bitcoin',
   per1: 1e8,
-  unit: 'BTC'
+  unit: 'BTC',
+  messagePrefix: '\x18Bitcoin Signed Message:\n'
 }
 
 var main = Object.assign({}, {


### PR DESCRIPTION
For BTC use: `\x18Bitcoin Signed Message:\n`
For alts use: `\19${name} Signed Message:\n`

Source: https://github.com/bitcoinjs/bitcoinjs-lib/blob/v3.3.2/src/networks.js