### PR TITLE
fix bip32 versions for ltc and add for dgb/doge

### DIFF
--- a/lib/coins/dgb.js
+++ b/lib/coins/dgb.js
@@ -26,6 +26,10 @@ var main = Object.assign({}, {
   ],
   // base58Prefixes
   versions: {
+    bip32: {
+      private: 0x0488ade4,
+      public: 0x0488b21e
+    },
     bip44: 0x80000014,
     private: 0x80,
     public: 0x1e,

--- a/lib/coins/doge.js
+++ b/lib/coins/doge.js
@@ -32,6 +32,10 @@ var main = Object.assign({}, {
 var test = Object.assign({}, {
   hashGenesisBlock: 'bb0a78264637406b6360aad926284d544d7049f45189db5664f3c4d07350559e',
   versions: {
+    bip32: {
+      private: 0x04358394,
+      public: 0x043587cf
+    },
     bip44: 1,
     private: 0xf1,
     public: 0x71,

--- a/lib/coins/ltc.js
+++ b/lib/coins/ltc.js
@@ -1,4 +1,4 @@
-// https://github.com/litecoin-project/litecoin/blob/master-0.10/src/chainparams.cpp
+// https://github.com/litecoin-project/litecoin/blob/0.16/src/chainparams.cpp
 
 var common = {
   name: 'Litecoin',
@@ -20,8 +20,8 @@ var main = Object.assign({}, {
   ],
   versions: {
     bip32: {
-      private: 0x019d9cfe,
-      public: 0x019da462
+      private: 0x0488ade4,
+      public: 0x0488b21e
     },
     bip44: 2,
     private: 0xb0,
@@ -35,8 +35,8 @@ var test = Object.assign({}, {
   hashGenesisBlock: 'f5ae71e26c74beacc88382716aced69cddf3dffff24f384e1808905e0188f68f',
   versions: {
     bip32: {
-      private: 0x0436ef7d,
-      public: 0x0436f6e1
+      private: 0x04358394,
+      public: 0x043587cf
     },
     bip44: 1,
     private: 0xef,


### PR DESCRIPTION
Any ideas from where LTC versions came?
https://github.com/cryptocoinjs/coininfo/commit/cebae8dc73992a29e238aa4903d1e5ee15761efb#diff-0db2151f14b143bd0412e30f40041748R13 ? @jprichardson ?