### PR TITLE
Add bech32 prefixes

### DIFF
--- a/lib/coininfo.js
+++ b/lib/coininfo.js
@@ -68,6 +68,7 @@ coins.forEach(function (coin) {
 function toBitcoinJS () {
   return Object.assign({}, this, {
     messagePrefix: this.messagePrefix || ('\x19' + this.name + ' Signed Message:\n'),
+    bech32: this.bech32,
     bip32: {
       public: (this.versions.bip32 || {}).public,
       private: (this.versions.bip32 || {}).private

--- a/lib/coins/btc.js
+++ b/lib/coins/btc.js
@@ -19,6 +19,7 @@ var main = Object.assign({}, {
     // pchMessageStart
     magic: 0xd9b4bef9 // careful, sent over wire as little endian
   },
+  bech32: 'bc',
   // vSeeds
   seedsDns: [
     'seed.bitcoin.sipa.be',
@@ -49,6 +50,7 @@ var test = Object.assign({}, {
   protocol: {
     magic: 0x0709110b
   },
+  bech32: 'tb',
   seedsDns: [
     'testnet-seed.alexykot.me',
     'testnet-seed.bitcoin.schildbach.de',
@@ -74,6 +76,7 @@ var regtest = Object.assign({}, {
   protocol: {
     magic: 0xdab5bffa
   },
+  bech32: 'bcrt',
   seedsDns: [],
   versions: {
     bip32: {

--- a/lib/coins/btg.js
+++ b/lib/coins/btg.js
@@ -16,6 +16,7 @@ var main = Object.assign({}, {
     // pchMessageStart
     magic: 0x446d47e1 // careful, sent over wire as little endian
   },
+  bech32: 'btg',
   // vSeeds
   seedsDns: [
     'eu-dnsseed.bitcoingold-official.org',
@@ -42,6 +43,7 @@ var test = Object.assign({}, {
   protocol: {
     magic: 0x456e48e2
   },
+  bech32: 'tbtg',
   seedsDns: [
     'test-dnsseed.bitcoingold.org',
     'test-dnsseed.btcgpu.org',

--- a/lib/coins/dgb.js
+++ b/lib/coins/dgb.js
@@ -18,6 +18,7 @@ var main = Object.assign({}, {
     // pchMessageStart
     magic: 0xfac3b6da // careful, sent over wire as little endian
   },
+  bech32: 'dgb',
   // vSeeds
   seedsDns: [
     'seed.digibyte.io',

--- a/lib/coins/ltc.js
+++ b/lib/coins/ltc.js
@@ -11,6 +11,7 @@ var main = Object.assign({}, {
   protocol: {
     magic: 0xdbb6c0fb
   },
+  bech32: 'ltc',
   seedsDns: [
     'dnsseed.litecointools.com',
     'dnsseed.litecoinpool.org',
@@ -33,6 +34,7 @@ var main = Object.assign({}, {
 
 var test = Object.assign({}, {
   hashGenesisBlock: 'f5ae71e26c74beacc88382716aced69cddf3dffff24f384e1808905e0188f68f',
+  bech32: 'tltc',
   versions: {
     bip32: {
       private: 0x0436ef7d,

--- a/lib/coins/mona.js
+++ b/lib/coins/mona.js
@@ -12,6 +12,7 @@ var main = Object.assign({}, {
   protocol: {
     magic: 0xdbb6c0fb
   },
+  bech32: 'mona',
   seedsDns: [
     'dnsseed.monacoin.org'
   ],
@@ -36,6 +37,7 @@ var test = Object.assign({}, {
   protocol: {
     magic: 0xf1c8d2fd
   },
+  bech32: 'tmona',
   seedsDns: [
     'testnet-dnsseed.monacoin.org'
   ],

--- a/lib/coins/qtum.js
+++ b/lib/coins/qtum.js
@@ -16,6 +16,7 @@ var main = Object.assign({}, {
     // pchMessageStart
     magic: 0xd3a6cff1 // careful, sent over wire as little endian
   },
+  bech32: 'qc',
   // vSeeds
   seedsDns: [
     'qtum3.dynu.net'

--- a/lib/coins/vtc.js
+++ b/lib/coins/vtc.js
@@ -16,6 +16,7 @@ var main = Object.assign({}, {
     // pchMessageStart
     magic: 0xdab5bffa // careful, sent over wire as little endian
   },
+  bech32: 'vtc',
   // vSeeds
   seedsDns: [
     'useast1.vtconline.org',
@@ -46,6 +47,7 @@ var test = Object.assign({}, {
   protocol: {
     magic: 0x74726576
   },
+  bech32: 'tvtc',
   seedsDns: [
     'jlovejoy.mit.edu',
     'gertjaap.ddns.net',

--- a/test/coininfo.test.js
+++ b/test/coininfo.test.js
@@ -71,6 +71,7 @@ test('+ coininfo()', function (t) {
     var bitcoin = ci.bitcoin.main
     var bjsBitcoin = bitcoin.toBitcoinJS()
     t.equal(bjsBitcoin.wif, 0x80, 'should return a compatible bitcoinjs-lib')
+    t.equal(bjsBitcoin.bech32, 'bc', 'object has bech32 prefix')
     t.end()
   })
 


### PR DESCRIPTION
Adds bech32 prefixes for segwit coins which I know use bech32. 

Unsure how bitcore expects bech32 prefixes to be exported, would like input on that before merging.