### PR TITLE
Switch Digibyte scripthash bytes

### DIFF
--- a/lib/coins/dgb.js
+++ b/lib/coins/dgb.js
@@ -30,8 +30,8 @@ var main = Object.assign({}, {
     bip44: 0x80000014,
     private: 0x80,
     public: 0x1e,
-    scripthash: 0x05,
-    scripthash2: 0x3f // S-prefix addresses
+    scripthash: 0x3f, // new 'S' prefix
+    scripthash2: 0x05 // old '3' prefix
   }
 }, common)
 


### PR DESCRIPTION
The DGB client now uses `S` address prefixes (`0x3f` byte prefix) for script hash by default. It is time to move forward with using the `0x3f` byte as the default in `coininfo` as well. 