### PR TITLE
Fix Bitcoin Simnet magic

### DIFF
--- a/lib/coins/btc.js
+++ b/lib/coins/btc.js
@@ -96,7 +96,7 @@ var simnet = Object.assign({}, {
   port: 18555,
   portRpc: 18556,
   protocol: {
-    magic: 0xdab5bffa
+    magic: 0x12141c16
   },
   bech32: 'sb',
   seedsDns: [],


### PR DESCRIPTION
In https://github.com/cryptocoinjs/coininfo/pull/89 I specified wrong Simnet magic. This PR sets the correct one. Proof:
https://github.com/btcsuite/btcd/blob/a41498d578a99c1619037746abd916176ea61052/wire/protocol.go#L159