### PR TITLE
Use object shorthand for properties

### DIFF
--- a/lib/coins/bch.js
+++ b/lib/coins/bch.js
@@ -87,7 +87,7 @@ var regtest = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test,
-  regtest: regtest
+  main,
+  test,
+  regtest
 }

--- a/lib/coins/blk.js
+++ b/lib/coins/blk.js
@@ -36,6 +36,6 @@ var main = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
+  main,
   test: null
 }

--- a/lib/coins/btc.js
+++ b/lib/coins/btc.js
@@ -113,8 +113,8 @@ var simnet = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test,
-  regtest: regtest,
-  simnet: simnet
+  main,
+  test,
+  regtest,
+  simnet
 }

--- a/lib/coins/btg.js
+++ b/lib/coins/btg.js
@@ -62,6 +62,6 @@ var test = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test
+  main,
+  test
 }

--- a/lib/coins/dash.js
+++ b/lib/coins/dash.js
@@ -63,6 +63,6 @@ var test = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test
+  main,
+  test
 }

--- a/lib/coins/dcr.js
+++ b/lib/coins/dcr.js
@@ -56,6 +56,6 @@ var test = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test
+  main,
+  test
 }

--- a/lib/coins/dgb.js
+++ b/lib/coins/dgb.js
@@ -35,4 +35,4 @@ var main = Object.assign({}, {
   }
 }, common)
 
-module.exports = { main: main }
+module.exports = { main }

--- a/lib/coins/doge.js
+++ b/lib/coins/doge.js
@@ -40,6 +40,6 @@ var test = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test
+  main,
+  test
 }

--- a/lib/coins/grs.js
+++ b/lib/coins/grs.js
@@ -86,7 +86,7 @@ var regtest = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test,
-  regtest: regtest
+  main,
+  test,
+  regtest
 }

--- a/lib/coins/ltc.js
+++ b/lib/coins/ltc.js
@@ -49,6 +49,6 @@ var test = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test
+  main,
+  test
 }

--- a/lib/coins/mona.js
+++ b/lib/coins/mona.js
@@ -55,6 +55,6 @@ var test = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test
+  main,
+  test
 }

--- a/lib/coins/nbt.js
+++ b/lib/coins/nbt.js
@@ -30,5 +30,5 @@ var main = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main
+  main
 }

--- a/lib/coins/nmc.js
+++ b/lib/coins/nmc.js
@@ -14,6 +14,6 @@ var main = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
+  main,
   test: null
 }

--- a/lib/coins/ppc.js
+++ b/lib/coins/ppc.js
@@ -64,6 +64,6 @@ var test = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test
+  main,
+  test
 }

--- a/lib/coins/qtum.js
+++ b/lib/coins/qtum.js
@@ -35,5 +35,5 @@ var main = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main
+  main
 }

--- a/lib/coins/rdd.js
+++ b/lib/coins/rdd.js
@@ -24,6 +24,6 @@ var test = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test
+  main,
+  test
 }

--- a/lib/coins/rvn.js
+++ b/lib/coins/rvn.js
@@ -54,6 +54,6 @@ var test = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test
+  main,
+  test
 }

--- a/lib/coins/via.js
+++ b/lib/coins/via.js
@@ -51,6 +51,6 @@ var test = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test
+  main,
+  test
 }

--- a/lib/coins/vtc.js
+++ b/lib/coins/vtc.js
@@ -85,7 +85,7 @@ var regtest = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test,
-  regtest: regtest
+  main,
+  test,
+  regtest
 }

--- a/lib/coins/zec.js
+++ b/lib/coins/zec.js
@@ -60,6 +60,6 @@ var test = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test
+  main,
+  test
 }


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility: This change is not compatible with IE 11, but it seems like you are using `Object.assign` which isn't compatible either. I was unable to find an explicitly stated supported browser version