### PR TITLE
Use object shorthand for properties

### DIFF
--- a/lib/coins/cbn.js
+++ b/lib/coins/cbn.js
@@ -80,7 +80,7 @@ var regtest = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test,
-  regtest: regtest
+  main,
+  test,
+  regtest
 }

--- a/lib/coins/city.js
+++ b/lib/coins/city.js
@@ -55,6 +55,6 @@ var test = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test
+  main,
+  test
 }

--- a/lib/coins/dnr.js
+++ b/lib/coins/dnr.js
@@ -41,6 +41,6 @@ var test = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test
+  main,
+  test
 }

--- a/lib/coins/x42.js
+++ b/lib/coins/x42.js
@@ -53,6 +53,6 @@ var test = Object.assign({}, {
 }, common)
 
 module.exports = {
-  main: main,
-  test: test
+  main,
+  test
 }


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility: This change is not compatible with IE 11, but it seems like you are using `Object.assign` which isn't compatible either. I was unable to find an explicitly stated supported browser version

follow up of: #97 