### PR TITLE
Added bip32 (base58Prefixes) for doge testnet

### DIFF
--- a/lib/coins/doge.js
+++ b/lib/coins/doge.js
@@ -37,6 +37,10 @@ var test = Object.assign({}, {
     'testseed.jrn.me.uk'
   ],
   versions: {
+    bip32: {
+      private: 0x04358394,
+      public: 0x043587cf
+    },
     bip44: 1,
     private: 0xf1,
     public: 0x71,


### PR DESCRIPTION
Values are taken from https://github.com/dogecoin/dogecoin/blob/master/src/chainparams.cpp#L328-L329